### PR TITLE
use user managed identity to auth to speech instead of key

### DIFF
--- a/speech-recognition/package.json
+++ b/speech-recognition/package.json
@@ -1,0 +1,13 @@
+{
+    "name": "speechToTextService",
+    "version": "0.1.0",
+    "description": "",
+    "dependencies": {
+      "@azure/identity": "^4.1.0",
+      "microsoft-cognitiveservices-speech-sdk": "^1.36.0"
+    },
+    "devDependencies": {
+      "typescript": "^4.7.3"
+    }
+  }
+  

--- a/speech-recognition/requirements.txt
+++ b/speech-recognition/requirements.txt
@@ -1,0 +1,2 @@
+azure-cognitiveservices-speech=1.36.0
+azure-identity=1.16.0


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
- use user MI to auth to speech instead of key.
- since app code isn't completely ready, this is a draft PR as a sample on how to use user managed identity. 
- Another part of change to make user MI work is to update /infra module biceps, such as creating a user managed identity, grant speech RBAC role to it etc. Since /infra folder isn't ready now, the change will be made after that.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[ ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->